### PR TITLE
🐛 should delineate an invalid token from a legit denial

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,23 +19,20 @@ export default function({ egoURL = process.env.EGO_API, accessRules = [] }) {
     const token = authorization ? authorization.split(' ')[1] : req.query.key;
 
     let valid = false;
-    let error;
     try {
       valid = token && (await verifyJWT({ token, egoURL }));
     } catch (e) {
-      error = e;
       valid = false;
     }
 
-    if (
-      !validateAccessRules({
-        url: req.originalUrl,
-        user: get(valid, 'context.user', {}),
-        valid,
-        accessRules,
-      })
-    ) {
-      res.status(401).json(error || { message: 'unauthorized' });
+    const errorCode = validateAccessRules({
+      url: req.originalUrl,
+      user: get(valid, 'context.user', {}),
+      valid,
+      accessRules,
+    });
+    if (errorCode) {
+      res.status(errorCode).json({ message: 'unauthorized' });
     } else {
       req.jwt = { ...jwt.decode(token), valid };
       next();

--- a/src/index.js
+++ b/src/index.js
@@ -25,14 +25,14 @@ export default function({ egoURL = process.env.EGO_API, accessRules = [] }) {
       valid = false;
     }
 
-    const errorCode = validateAccessRules({
+    const error = validateAccessRules({
       url: req.originalUrl,
       user: get(valid, 'context.user', {}),
       valid,
       accessRules,
     });
-    if (errorCode) {
-      res.status(errorCode).json({ message: 'unauthorized' });
+    if (error) {
+      res.status(error.code).json({ message: error.message });
     } else {
       req.jwt = { ...jwt.decode(token), valid };
       next();

--- a/src/utils/validateAccessRules.js
+++ b/src/utils/validateAccessRules.js
@@ -30,7 +30,7 @@ const validateAccessRules = ({ url, user, accessRules, valid }) => {
     );
   const validity = valid ? 0 : 401;
   return rule
-    ? rule.type === 'deny' ? 403 : !rule.tokenRequired ? 0 : validity
+    ? rule.type === 'deny' ? 403 : rule.tokenExempt ? 0 : validity
     : validity;
 };
 

--- a/src/utils/validateAccessRules.js
+++ b/src/utils/validateAccessRules.js
@@ -2,6 +2,9 @@ import { reverse } from 'lodash/fp';
 import { keys } from 'lodash';
 import pathToRegexp from 'path-to-regexp';
 
+const UNAUTHORIZED = { code: 401, message: 'unauthorized' };
+const FORBIDDEN = { code: 403, message: 'forbidden' };
+
 const toLower = x => (x || '').toLowerCase();
 
 const ensureArray = x => (Array.isArray(x) ? x : [x]);
@@ -28,9 +31,9 @@ const validateAccessRules = ({ url, user, accessRules, valid }) => {
         !r.status || arraysShareValue(r.status, [user.status]),
       ].every(Boolean),
     );
-  const validity = valid ? 0 : 401;
+  const validity = valid ? 0 : UNAUTHORIZED;
   return rule
-    ? rule.type === 'deny' ? 403 : rule.tokenExempt ? 0 : validity
+    ? rule.type === 'deny' ? FORBIDDEN : rule.tokenExempt ? 0 : validity
     : validity;
 };
 

--- a/src/utils/validateAccessRules.js
+++ b/src/utils/validateAccessRules.js
@@ -28,7 +28,10 @@ const validateAccessRules = ({ url, user, accessRules, valid }) => {
         !r.status || arraysShareValue(r.status, [user.status]),
       ].every(Boolean),
     );
-  return rule ? rule.type === 'allow' && (!rule.tokenRequired || valid) : valid;
+  const validity = valid ? 0 : 401;
+  return rule
+    ? rule.type === 'deny' ? 403 : !rule.tokenRequired ? 0 : validity
+    : validity;
 };
 
 export default validateAccessRules;

--- a/test/utils/validateAccessRules.test.js
+++ b/test/utils/validateAccessRules.test.js
@@ -2,6 +2,8 @@ import { validateAccessRules } from '../../src/utils';
 
 describe('validateAccessRules', () => {
   describe('ruleSetOne', () => {
+    const UNAUTHORIZED = { code: 401, message: 'unauthorized' };
+    const FORBIDDEN = { code: 403, message: 'forbidden' };
     const ruleSetOne = [
       {
         type: 'allow',
@@ -33,7 +35,7 @@ describe('validateAccessRules', () => {
           user: { roles: ['user'] },
           accessRules: ruleSetOne,
         }),
-      ).toEqual(403));
+      ).toEqual(FORBIDDEN));
 
     test('deny non-root from role', () =>
       expect(
@@ -42,7 +44,7 @@ describe('validateAccessRules', () => {
           user: { roles: ['user'] },
           accessRules: ruleSetOne,
         }),
-      ).toEqual(403));
+      ).toEqual(FORBIDDEN));
 
     test('deny non-root from status', () =>
       expect(
@@ -51,9 +53,9 @@ describe('validateAccessRules', () => {
           user: { roles: ['user'], status: 'pending' },
           accessRules: ruleSetOne,
         }),
-      ).toEqual(403));
+      ).toEqual(FORBIDDEN));
 
-    test('when token is invalid', () =>
+    test('when user is not yet approved', () =>
       expect(
         validateAccessRules({
           url: '/a/graphql',
@@ -61,7 +63,7 @@ describe('validateAccessRules', () => {
           accessRules: ruleSetOne,
           valid: false,
         }),
-      ).toEqual(403));
+      ).toEqual(FORBIDDEN));
 
     test('allow non-root from status', () =>
       expect(
@@ -81,7 +83,7 @@ describe('validateAccessRules', () => {
           accessRules: ruleSetOne,
           valid: false,
         }),
-      ).toEqual(401));
+      ).toEqual(UNAUTHORIZED));
 
     test('allow non-root from status with gql extension', () =>
       expect(


### PR DESCRIPTION
This does two things:
- fixes a bug w/ the token required / exempted logic
- returns a 403 on deny, 401 on invalid token